### PR TITLE
Make the scroll view size based on its children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,8 +106,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -369,7 +368,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
@@ -379,14 +377,12 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -399,7 +395,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -407,8 +402,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -519,7 +513,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -532,7 +525,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -607,7 +599,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -650,6 +641,11 @@
       "integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g==",
       "dev": true
     },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+    },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
@@ -667,6 +663,17 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
@@ -1150,7 +1157,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1159,8 +1165,7 @@
         "core-js": {
           "version": "2.5.5",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-          "dev": true
+          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
         }
       }
     },
@@ -1168,7 +1173,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "babel-traverse": "^6.26.0",
@@ -1180,8 +1184,7 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         }
       }
     },
@@ -1189,7 +1192,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
         "babel-messages": "^6.23.0",
@@ -1205,14 +1207,12 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1220,8 +1220,7 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
         }
       }
     },
@@ -1229,7 +1228,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
@@ -1240,8 +1238,7 @@
         "to-fast-properties": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
         }
       }
     },
@@ -1986,8 +1983,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.9.1",
@@ -2269,8 +2265,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "exec-sh": {
       "version": "0.2.1",
@@ -3323,7 +3318,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -3540,7 +3534,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -4534,8 +4527,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -4705,8 +4697,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -5396,8 +5387,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^16.2.0"
   },
   "dependencies": {
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "parse-color": "^1.0.0",
     "react-reconciler": "^0.11.0"
   },
@@ -42,6 +43,9 @@
     "presets": [
       "es2015",
       "react"
+    ],
+    "plugins": [
+      "transform-class-properties"
     ]
   },
   "jest": {

--- a/src/apply_styles.js
+++ b/src/apply_styles.js
@@ -62,7 +62,7 @@ function applyTextStyles (view, styles) {
 
 module.exports = function applyStyles (view, styles = {}) {
   view.setStyle(styles)
-  
+
   if (view instanceof gui.Label || view instanceof gui.Entry) {
     applyTextStyles(view, styles)
   }

--- a/src/components/__tests__/scroll.spec.js
+++ b/src/components/__tests__/scroll.spec.js
@@ -6,19 +6,18 @@ const { win32 } = require('../../utils')
 describe('scroll', () => {
   it('should render the component correctly', done => {
     createTestSuite(render => {
-      const contentSize = { width: 100, height: 100 }
       const overlayScrollbar = true
       const hpolicy = 'never'
       const vpolicy = 'always'
+      const containerSize = { width: 100, height: 100 }
 
       const ele = (
         <scroll
-          contentSize={contentSize}
           overlayScrollbar={overlayScrollbar}
           hpolicy={hpolicy}
           vpolicy={vpolicy}
         >
-          <container />
+          <container style={containerSize} />
         </scroll>
       )
 
@@ -28,8 +27,10 @@ describe('scroll', () => {
         const size = scroll.getContentSize()
         // NOTE: The value may be not accurate in windows
         if (!win32) {
-          expect(size.width).toBe(contentSize.width)
-          expect(size.height).toBe(contentSize.height)
+          // The content size should be determined by the scroll views
+          // children
+          expect(size.width).toBe(containerSize.width)
+          expect(size.height).toBe(containerSize.height)
         }
         // expect(scroll.isOverlayScrollbar()).toBe(overlayScrollbar)
         const policies = scroll.getScrollbarPolicy()

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -1,6 +1,6 @@
 const { Button } = require('gui')
 const Base = require('./base')
-const { shoudUpdate } = require('../utils')
+const { shouldUpdate } = require('../utils')
 
 // TODO: add button style and border
 module.exports = class Wrapper extends Base {
@@ -20,11 +20,11 @@ module.exports = class Wrapper extends Base {
   update(lastProps, props) {
     super.update(lastProps, props)
 
-    if (shoudUpdate(props, lastProps, 'title')) {
+    if (shouldUpdate(props, lastProps, 'title')) {
       this._ele.setTitle(props.title)
     }
 
-    if (shoudUpdate(props, lastProps, 'image')) {
+    if (shouldUpdate(props, lastProps, 'image')) {
       this._ele.setImage(props.image)
     }
 

--- a/src/components/group.js
+++ b/src/components/group.js
@@ -1,7 +1,7 @@
 const { View, Group } = require('gui')
 const Base = require('./base')
 const { STRICT_CHECK, warn } = require('../utils')
-const { shoudUpdate } = require('../utils')
+const { shouldUpdate } = require('../utils')
 
 module.exports = class Wrapper extends Base {
   constructor(props) {
@@ -13,7 +13,7 @@ module.exports = class Wrapper extends Base {
   update(lastProps, props) {
     super.update(lastProps, props)
 
-    if (shoudUpdate(props, lastProps, 'title')) {
+    if (shouldUpdate(props, lastProps, 'title')) {
       this._ele.setTitle(props.title)
     }
   }

--- a/src/components/label.js
+++ b/src/components/label.js
@@ -1,6 +1,6 @@
 const { Label } = require('gui')
 const Base = require('./base')
-const { shoudUpdate } = require('../utils')
+const { shouldUpdate } = require('../utils')
 
 module.exports = class Wrapper extends Base {
   constructor(props) {
@@ -12,15 +12,15 @@ module.exports = class Wrapper extends Base {
   update(lastProps, props) {
     super.update(lastProps, props)
 
-    if (shoudUpdate(props, lastProps, 'text')) {
+    if (shouldUpdate(props, lastProps, 'text')) {
       this._ele.setText(props.text)
     }
 
-    if (shoudUpdate(props, lastProps, 'align')) {
+    if (shouldUpdate(props, lastProps, 'align')) {
       this._ele.setAlign(props.align)
     }
 
-    if (shoudUpdate(props, lastProps, 'vAlign')) {
+    if (shouldUpdate(props, lastProps, 'vAlign')) {
       this._ele.setVAlign(props.vAlign)
     }
   }

--- a/src/components/progress_bar.js
+++ b/src/components/progress_bar.js
@@ -1,6 +1,6 @@
 const { ProgressBar } = require('gui')
 const Base = require('./base')
-const { shoudUpdate } = require('../utils')
+const { shouldUpdate } = require('../utils')
 
 module.exports = class Wrapper extends Base {
   constructor(props) {
@@ -12,11 +12,11 @@ module.exports = class Wrapper extends Base {
   update(lastProps, props) {
     super.update(lastProps, props)
 
-    if (shoudUpdate(props, lastProps, 'value')) {
+    if (shouldUpdate(props, lastProps, 'value')) {
       this._ele.setValue(props.value)
     }
 
-    if (shoudUpdate(props, lastProps, 'indeterminate')) {
+    if (shouldUpdate(props, lastProps, 'indeterminate')) {
       this._ele.setIndeterminate(props.indeterminate)
     }
 

--- a/src/components/scroll.js
+++ b/src/components/scroll.js
@@ -1,4 +1,4 @@
-const { Scroll } = require('gui')
+const { Scroll, Container } = require('gui')
 const Base = require('./base')
 const { warn } = require('./log')
 const { shoudUpdate, win32 } = require('../utils')
@@ -6,6 +6,10 @@ const { shoudUpdate, win32 } = require('../utils')
 module.exports = class Wrapper extends Base {
   constructor(props) {
     super(Scroll.create())
+
+    this.contentView = Container.create()
+    this.contentView.setStyle({ flex: 1 })
+    this._ele.setContentView(this.contentView)
 
     this.update(null, props)
   }
@@ -28,11 +32,17 @@ module.exports = class Wrapper extends Base {
   }
 
   addChildView(child) {
-    this._ele.setContentView(child._ele)
+    this.contentView.addChildView(child)
+    this._ele.setContentSize(this.contentView.getPreferredSize())
   }
 
-  // eslint-disable-next-line
-  insertBefore() {
-    warn('insertBefore of scroll in a non-op')
+  removeChildView(child) {
+    this.contentView.removeChildView(child)
+    this._ele.setContentSize(this.contentView.getPreferredSize())
+  }
+
+  insertBefore(child, beforeChild) {
+    this.contentView.insertBefore(child, beforeChild)
+    this._ele.setContentSize(this.contentView.getPreferredSize())
   }
 }

--- a/src/components/scroll.js
+++ b/src/components/scroll.js
@@ -1,7 +1,7 @@
 const { Scroll, Container } = require('gui')
 const Base = require('./base')
 const { warn } = require('./log')
-const { shoudUpdate, win32 } = require('../utils')
+const { shouldUpdate, win32 } = require('../utils')
 
 module.exports = class Wrapper extends Base {
   constructor(props) {
@@ -17,32 +17,34 @@ module.exports = class Wrapper extends Base {
   update(lastProps, props) {
     super.update(lastProps, props)
 
-    if (shoudUpdate(props, lastProps, 'contentSize')) {
-      this._ele.setContentSize(props.contentSize)
-    }
+    this._ele.setContentSize(this.contentView.getPreferredSize())
 
     // TODO:
     if (props.hpolicy && props.vpolicy) {
       this._ele.setScrollbarPolicy(props.hpolicy, props.vpolicy)
     }
 
-    if (!win32 && shoudUpdate(props, lastProps, 'overlayScrollbar')) {
+    if (!win32 && shouldUpdate(props, lastProps, 'overlayScrollbar')) {
       this._ele.setOverlayScrollbar(props.overlayScrollbar)
     }
   }
 
-  addChildView(child) {
-    this.contentView.addChildView(child)
+  // I'm not sure why it is the case here and not anywhere else but
+  // in the case of Scroll these next 3 methods were losing their
+  // scoping so making them class properties and arrow functions
+  // will ensure they don't lose their scope
+  addChildView = (child) => {
+    this.contentView.addChildView(child._ele)
     this._ele.setContentSize(this.contentView.getPreferredSize())
   }
 
-  removeChildView(child) {
-    this.contentView.removeChildView(child)
+  removeChildView = (child) => {
+    this.contentView.removeChildView(child._ele)
     this._ele.setContentSize(this.contentView.getPreferredSize())
   }
 
-  insertBefore(child, beforeChild) {
-    this.contentView.insertBefore(child, beforeChild)
+  insertBefore = (child, beforeChild) => {
+    this.contentView.insertBefore(child._ele, beforeChild._ele)
     this._ele.setContentSize(this.contentView.getPreferredSize())
   }
 }

--- a/src/components/text_edit.js
+++ b/src/components/text_edit.js
@@ -1,6 +1,6 @@
 const { TextEdit } = require('gui')
 const Base = require('./base')
-const { shoudUpdate, win32 } = require('../utils')
+const { shouldUpdate, win32 } = require('../utils')
 
 module.exports = class Wrapper extends Base {
   constructor(props) {
@@ -16,7 +16,7 @@ module.exports = class Wrapper extends Base {
   update(lastProps, props) {
     super.update(lastProps, props)
 
-    if (shoudUpdate(props, lastProps, 'text')) {
+    if (shouldUpdate(props, lastProps, 'text')) {
       this._ele.setText(props.text)
     }
 
@@ -25,7 +25,7 @@ module.exports = class Wrapper extends Base {
       this._ele.setScrollbarPolicy(props.hpolicy, props.vpolicy)
     }
 
-    if (!win32 && shoudUpdate(props, lastProps, 'overlayScrollbar')) {
+    if (!win32 && shouldUpdate(props, lastProps, 'overlayScrollbar')) {
       this._ele.setOverlayScrollbar(props.overlayScrollbar)
     }
 

--- a/src/components/vibrant.js
+++ b/src/components/vibrant.js
@@ -1,6 +1,6 @@
 const { Vibrant } = require('gui')
 const Container = require('./container')
-const { shoudUpdate } = require('../utils')
+const { shouldUpdate } = require('../utils')
 
 module.exports = class Wrapper extends Container {
   constructor(props) {
@@ -13,11 +13,11 @@ module.exports = class Wrapper extends Container {
   update(lastProps, props) {
     super.update(lastProps, props)
 
-    if (shoudUpdate(props, lastProps, 'material')) {
+    if (shouldUpdate(props, lastProps, 'material')) {
       this._ele.setMaterial(props.material)
     }
 
-    if (shoudUpdate(props, lastProps, 'blendingMode')) {
+    if (shouldUpdate(props, lastProps, 'blendingMode')) {
       this._ele.setBlendingMode(props.blendingMode)
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,7 +30,7 @@ function warn(msg) {
   console.warn(msg)
 }
 
-function shoudUpdate(props, lastProps, propName) {
+function shouldUpdate(props, lastProps, propName) {
   if (!props || props[propName] === undefined) {
     return false
   }
@@ -49,6 +49,6 @@ module.exports = {
   now,
   scheduleDeferredCallback,
   warn,
-  shoudUpdate,
+  shouldUpdate,
   win32,
 }


### PR DESCRIPTION
It used to be that you had to pass in a contentSize prop in order to get the scroll view to size properly and scroll properly. With this change it makes it possible to just use the scroll view and style it to the size you want it to be and it will handle ensuring that it's scrollable content is sized to scroll properly.

It also makes it so that you don't have to have a `<container>` as the immediate child of `<scroll>`. You can now have 'n' children inside of a `<scroll>`.

Also fixed some spelling `shoud` -> `should`